### PR TITLE
Remove Scripts directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,25 @@ If you answered yes at least once, then this project will have you covered!
 This project contains a bunch of Python releases packaged in zip archives. The archives are created from files installed by the official Python installer, nothing else. Each version will have a 32-bit and 64-bit version available.
 
 Check out [releases](https://github.com/oswjk/portablepython/releases) for downloads!
+
+# Recreating scripts
+
+A normal Python installation can be configured to have a Scripts directory that contains `pip` and `easy_install` scripts that you can invoke directly.
+
+The portable zip file does not contain this directory. If you need it, it is easy to recreate with the `ensurepip` package.
+
+First, you need to uninstall pip and setuptools:
+
+```
+python -m pip uninstall setuptools pip
+```
+
+Now you can run the `ensurepip` package to install `pip` and `setuptools` and to create the scripts:
+
+```
+python -m ensurepip --default-pip
+```
+
+Make sure that the Python you are invoking, is the correct one! You can do this for example by specifying the full path to the Python executable when entering the commands above.
+
+That should be all!

--- a/download.ps1
+++ b/download.ps1
@@ -38,4 +38,6 @@ if ($env:PYVERSION -like "3.*") {
     Get-ChildItem -Include "*.pyc" -Recurse -Force | Remove-Item -Force
 }
 
-Remove-Item -Recurse -Force $targetdir\Scripts
+if (Test-Path $targetdir\Scripts) {
+    Remove-Item -Recurse -Force $targetdir\Scripts
+}

--- a/download.ps1
+++ b/download.ps1
@@ -38,7 +38,7 @@ if ($env:PYVERSION -like "3.*") {
     Get-ChildItem -Include __pycache__ -Recurse -Force | Remove-Item -Force -Recurse
 } else {
     Write-Output "Installing Python to $targetdir"
-    Start-Process -FilePath msiexec -ArgumentList "/qn","/i","$target","/L*V","$logfile","TARGETDIR=$targetdir","ADDLOCAL=DefaultFeature,TclTk,Documentation,Tools","REMOVE=Extensions,Testsuite" -Wait
+    Start-Process -FilePath msiexec -ArgumentList "/qn","/fa","/i","$target","/L*V","$logfile","TARGETDIR=$targetdir","ADDLOCAL=DefaultFeature,TclTk,Documentation,Tools","REMOVE=Extensions,Testsuite" -Wait
     
     Write-Output "Removing .pyc files"
     Get-ChildItem -Include "*.pyc" -Recurse -Force | Remove-Item -Force

--- a/download.ps1
+++ b/download.ps1
@@ -37,8 +37,11 @@ if ($env:PYVERSION -like "3.*") {
     Write-Output "Removing __pycache__ directories"
     Get-ChildItem -Include __pycache__ -Recurse -Force | Remove-Item -Force -Recurse
 } else {
+    Write-Output "Removing existing Python installation if there is one"
+    Start-Process -FilePath msiexec -ArgumentList "/qn","/x","$target" -Wait
+    
     Write-Output "Installing Python to $targetdir"
-    Start-Process -FilePath msiexec -ArgumentList "/qn","/fa","/i","$target","/L*V","$logfile","TARGETDIR=$targetdir","ADDLOCAL=DefaultFeature,TclTk,Documentation,Tools","REMOVE=Extensions,Testsuite" -Wait
+    Start-Process -FilePath msiexec -ArgumentList "/qn","/i","$target","/L*V","$logfile","TARGETDIR=$targetdir","ADDLOCAL=DefaultFeature,TclTk,Documentation,Tools","REMOVE=Extensions,Testsuite" -Wait
     
     Write-Output "Removing .pyc files"
     Get-ChildItem -Include "*.pyc" -Recurse -Force | Remove-Item -Force

--- a/download.ps1
+++ b/download.ps1
@@ -37,3 +37,5 @@ if ($env:PYVERSION -like "3.*") {
     Start-Process -FilePath msiexec -ArgumentList "/qn","/i","$target","/L*V","$logfile","TARGETDIR=$targetdir","ADDLOCAL=DefaultFeature,TclTk,Documentation,Tools","REMOVE=Extensions,Testsuite" -Wait
     Get-ChildItem -Include "*.pyc" -Recurse -Force | Remove-Item -Force
 }
+
+Remove-Item -Recurse -Force $targetdir\Scripts

--- a/download.ps1
+++ b/download.ps1
@@ -22,6 +22,7 @@ Write-Output "Target: $target"
 Write-Output "Target dir: $targetdir"
 Write-Output "Log file: $logfile"
 
+Write-Output "Downloading $url"
 $client = New-Object System.Net.WebClient
 $client.DownloadFile($url, $target)
 
@@ -29,15 +30,21 @@ if ($env:PYVERSION -like "3.*") {
     # Replace TARGET_DIR in unattend.xml.in with our target directory
     ((Get-Content -path unattend.xml.in -raw) -replace 'TARGET_DIR',$targetdir) | Set-Content -path unattend.xml
 
+    Write-Output "Installing Python to $targetdir"
     Start-Process -FilePath "$target" -ArgumentList "/quiet","/log","$logfile" -Wait
 
     # Remove all __pycache__ directories
+    Write-Output "Removing __pycache__ directories"
     Get-ChildItem -Include __pycache__ -Recurse -Force | Remove-Item -Force -Recurse
 } else {
+    Write-Output "Installing Python to $targetdir"
     Start-Process -FilePath msiexec -ArgumentList "/qn","/i","$target","/L*V","$logfile","TARGETDIR=$targetdir","ADDLOCAL=DefaultFeature,TclTk,Documentation,Tools","REMOVE=Extensions,Testsuite" -Wait
+    
+    Write-Output "Removing .pyc files"
     Get-ChildItem -Include "*.pyc" -Recurse -Force | Remove-Item -Force
 }
 
 if (Test-Path $targetdir\Scripts) {
+    Write-Output "Removing $targetdir\Scripts"
     Remove-Item -Recurse -Force $targetdir\Scripts
 }


### PR DESCRIPTION
The Scripts directory contains executables that won't work on user system. The user needs to run ensurepip to make recreate the scripts.